### PR TITLE
Add support for .NET Standard 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -229,5 +229,4 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
-/SecurityDriven.Inferno.Tests.sln
 .vs/

--- a/HMACTests.cs
+++ b/HMACTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
 using System.Security.Cryptography;
@@ -195,9 +195,9 @@ namespace SecurityDriven.Inferno.Tests
 
 		protected override HashAlgorithm CreateHashAlgorithm()
 		{
-#if NET462
+#if NETFRAMEWORK
 			return new SHA1Cng();
-#elif NETCOREAPP2_1
+#else
 			return SHA1.Create();
 #endif
 		}
@@ -263,9 +263,9 @@ namespace SecurityDriven.Inferno.Tests
 
 		protected override HashAlgorithm CreateHashAlgorithm()
 		{
-#if NET462
+#if NETFRAMEWORK
 			return new SHA256Cng();
-#elif NETCOREAPP2_1
+#else
 			return SHA256.Create();
 #endif
 		}
@@ -332,9 +332,9 @@ namespace SecurityDriven.Inferno.Tests
 
 		protected override HashAlgorithm CreateHashAlgorithm()
 		{
-#if NET462
+#if NETFRAMEWORK
 			return new SHA384Cng();
-#elif NETCOREAPP2_1
+#else
 			return SHA384.Create();
 #endif
 		}
@@ -401,9 +401,9 @@ namespace SecurityDriven.Inferno.Tests
 
 		protected override HashAlgorithm CreateHashAlgorithm()
 		{
-#if NET462
+#if NETFRAMEWORK
 			return new SHA512Cng();
-#elif NETCOREAPP2_1
+#else
 			return SHA512.Create();
 #endif
 		}

--- a/SecurityDriven.Inferno.Tests.sln
+++ b/SecurityDriven.Inferno.Tests.sln
@@ -1,0 +1,42 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecurityDriven.Inferno.Tests", "SecurityDriven.Inferno.Tests.csproj", "{A687CB51-6F8D-4B96-A660-932EC1A4137C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecurityDriven.Inferno.TestsCore", "SecurityDriven.Inferno.TestsCore.csproj", "{F192D41C-7878-4AE5-88F8-AB3B062937F6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SecurityDriven.Inferno", "..\SecurityDriven.Inferno\SecurityDriven.Inferno.csproj", "{21B42623-1830-482A-A059-1FD55330A592}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+		DebugNETStandard|Any CPU = DebugNETStandard|Any CPU
+		ReleaseNETStandard|Any CPU = ReleaseNETStandard|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A687CB51-6F8D-4B96-A660-932EC1A4137C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A687CB51-6F8D-4B96-A660-932EC1A4137C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A687CB51-6F8D-4B96-A660-932EC1A4137C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A687CB51-6F8D-4B96-A660-932EC1A4137C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A687CB51-6F8D-4B96-A660-932EC1A4137C}.DebugNETStandard|Any CPU.ActiveCfg = Debug|Any CPU
+		{A687CB51-6F8D-4B96-A660-932EC1A4137C}.DebugNETStandard|Any CPU.Build.0 = Debug|Any CPU
+		{A687CB51-6F8D-4B96-A660-932EC1A4137C}.ReleaseNETStandard|Any CPU.ActiveCfg = Release|Any CPU
+		{A687CB51-6F8D-4B96-A660-932EC1A4137C}.ReleaseNETStandard|Any CPU.Build.0 = Release|Any CPU
+		{F192D41C-7878-4AE5-88F8-AB3B062937F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F192D41C-7878-4AE5-88F8-AB3B062937F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F192D41C-7878-4AE5-88F8-AB3B062937F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F192D41C-7878-4AE5-88F8-AB3B062937F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F192D41C-7878-4AE5-88F8-AB3B062937F6}.DebugNETStandard|Any CPU.ActiveCfg = DebugNETStandard|Any CPU
+		{F192D41C-7878-4AE5-88F8-AB3B062937F6}.DebugNETStandard|Any CPU.Build.0 = DebugNETStandard|Any CPU
+		{F192D41C-7878-4AE5-88F8-AB3B062937F6}.ReleaseNETStandard|Any CPU.ActiveCfg = ReleaseNETStandard|Any CPU
+		{F192D41C-7878-4AE5-88F8-AB3B062937F6}.ReleaseNETStandard|Any CPU.Build.0 = ReleaseNETStandard|Any CPU
+		{21B42623-1830-482A-A059-1FD55330A592}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21B42623-1830-482A-A059-1FD55330A592}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21B42623-1830-482A-A059-1FD55330A592}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21B42623-1830-482A-A059-1FD55330A592}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21B42623-1830-482A-A059-1FD55330A592}.DebugNETStandard|Any CPU.ActiveCfg = Debug|Any CPU
+		{21B42623-1830-482A-A059-1FD55330A592}.DebugNETStandard|Any CPU.Build.0 = Debug|Any CPU
+		{21B42623-1830-482A-A059-1FD55330A592}.ReleaseNETStandard|Any CPU.ActiveCfg = Release|Any CPU
+		{21B42623-1830-482A-A059-1FD55330A592}.ReleaseNETStandard|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/SecurityDriven.Inferno.TestsCore.csproj
+++ b/SecurityDriven.Inferno.TestsCore.csproj
@@ -1,19 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>netcoreapp2.1;net462;</TargetFrameworks>
 		<IsPackable>false</IsPackable>
-	</PropertyGroup>
-
-	<PropertyGroup Condition=" '$(TargetFramework)' == 'net462'">
-		<DefineConstants>NET462;NETFULL</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1'">
-		<DefineConstants>NETCOREAPP2_1</DefineConstants>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp2.1|AnyCPU'">
+		<Configurations>Debug;Release;DebugNETStandard;ReleaseNETStandard</Configurations>
 		<LangVersion>latest</LangVersion>
 	</PropertyGroup>
 
@@ -22,16 +12,17 @@
 		<PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
 		<PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-		<PackageReference Include="System.Security.Cryptography.Cng" Version="4.5.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" !$(Configuration.EndsWith('NETStandard')) ">
+		<ProjectReference Include="..\SecurityDriven.Inferno\SecurityDriven.Inferno.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<Reference Include="SecurityDriven.Inferno" Condition="'$(TargetFramework)' == 'netcoreapp2.1' ">
-			<HintPath>..\SecurityDriven.Inferno\bin\Release\netcoreapp2.1\SecurityDriven.Inferno.dll</HintPath>
-		</Reference>
-
-		<Reference Include="SecurityDriven.Inferno" Condition="'$(TargetFramework)' == 'net462' ">
-			<HintPath>..\SecurityDriven.Inferno\bin\Release\net462\SecurityDriven.Inferno.dll</HintPath>
+		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+		<PackageReference Include="System.Security.Cryptography.Cng" Version="4.5.0" />
+		<Reference Include="SecurityDriven.Inferno" Condition=" $(Configuration.EndsWith('NETStandard')) ">
+			<HintPath>..\SecurityDriven.Inferno\bin\$(Configuration.Replace('NETStandard', ''))\netstandard2.0\SecurityDriven.Inferno.dll</HintPath>
 		</Reference>
 	</ItemGroup>
 

--- a/UnitTests.cs
+++ b/UnitTests.cs
@@ -33,9 +33,9 @@ namespace SecurityDriven.Inferno.Tests
 			Assert.IsTrue(kind == PortableExecutableKinds.ILOnly);
 
 			string environment =
-#if NET462
+#if NETFRAMEWORK
 				"[.NET 4.6.2] " + Environment.Version;
-#elif NETCOREAPP2_1
+#else
 				"[CORE 2.1] " + Environment.Version + "\nFrom: " + System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
 
 #endif


### PR DESCRIPTION
Complement to https://github.com/sdrapkin/SecurityDriven.Inferno/pull/28

The solution has DebugNETStandard and ReleaseNETStandard configuration to test the netstandard2.0 library.